### PR TITLE
Replace md5 callback in port model

### DIFF
--- a/app/domains/domain/port/save.rb
+++ b/app/domains/domain/port/save.rb
@@ -5,6 +5,7 @@ module Domain
 
       def call(port)
         remove_excess_whitespace!(port)
+        store_md5(port)
         port.save!
       end
 
@@ -14,6 +15,10 @@ module Domain
         return unless port.family
         port.family.strip!
         port.family.gsub!(/\s+/, ' ')
+      end
+
+      def store_md5(port)
+        port.md5 = Service::FileData::ComputeMd5.call(port)
       end
     end
   end

--- a/app/models/port.rb
+++ b/app/models/port.rb
@@ -1,4 +1,3 @@
-require 'callbacks/file_hash_callbacks'
 class Port < ApplicationRecord
   validates :family,  presence: true, length: { maximum: 50},
                       format: { with: VALID_PORT_REGEX }
@@ -9,7 +8,6 @@ class Port < ApplicationRecord
   mount_uploader :data, ZipFileUploader
   validates_presence_of :data
   validates_size_of :data, maximum: 100.megabytes, message: 'File exceeds 100 MB size limit'
-  before_validation FileHashCallbacks.new
 
   # Override path
   def to_param

--- a/app/services/service/file_data/compute_md5.rb
+++ b/app/services/service/file_data/compute_md5.rb
@@ -1,0 +1,12 @@
+module Service
+  module FileData
+    module ComputeMd5
+      extend self
+
+      def call(object)
+        return unless object.data&.file&.file
+        Digest::MD5.hexdigest(object.data.file.read)
+      end
+    end
+  end
+end

--- a/test/domains/domain/port/save_test.rb
+++ b/test/domains/domain/port/save_test.rb
@@ -5,6 +5,7 @@ describe Domain::Port::Save do
 
   before do
     port.stubs(:save!)
+    Service::FileData::ComputeMd5.stubs(call: '1234')
   end
 
   it 'removes excess namespace in family' do
@@ -15,5 +16,11 @@ describe Domain::Port::Save do
   it 'saves the port' do
     port.expects(:save!)
     Domain::Port::Save.call(port)
+  end
+
+  it 'computes the file md5 hash' do
+    Service::FileData::ComputeMd5.expects(:call).returns('1234')
+    Domain::Port::Save.call(port)
+    port.md5.must_equal '1234'
   end
 end

--- a/test/models/port_test.rb
+++ b/test/models/port_test.rb
@@ -4,7 +4,9 @@ class PortTest < ActiveSupport::TestCase
 
   def setup
     @file = dummy_zip
-    @port = Port.new(family: "PRBoom+", version: "v2.5.1.3", data: @file)
+    @port = Port.new(
+      family: "PRBoom+", version: "v2.5.1.3", data: @file, md5: '1234'
+    )
   end
 
   test "should be valid" do
@@ -52,6 +54,7 @@ class PortTest < ActiveSupport::TestCase
   test "family + version should be unique" do
     duplicate_port = @port.dup
     duplicate_port.data = dummy_zip 1
+    duplicate_port.md5 = 'dup'
     @port.save
     assert_not duplicate_port.valid?
     duplicate_port.version = "v2.5.1.5"

--- a/test/services/service/file_data/compute_md5_test.rb
+++ b/test/services/service/file_data/compute_md5_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+describe Service::FileData::ComputeMd5 do
+  let(:md5) { Service::FileData::ComputeMd5.call(object) }
+
+  describe 'when the object has file data' do
+    # stub object.data.file.[file, read]
+    let(:object) {
+      stub(data: stub(file: stub(file: true, read: '1234')))
+    }
+
+    it 'returns the md5' do
+      md5.must_equal Digest::MD5.hexdigest('1234')
+    end
+  end
+
+  describe 'when the object has no file data' do
+    let(:object) { stub(data: nil) }
+
+    it 'returns nil' do
+      md5.must_be_nil
+    end
+  end
+end


### PR DESCRIPTION
I missed this when implementing the domain. Removes validation callback from the port model in favor of explicit calculation in the save action.