### PR TITLE
Simplify subcategories

### DIFF
--- a/app/helpers/demos_helper.rb
+++ b/app/helpers/demos_helper.rb
@@ -42,11 +42,6 @@ module DemosHelper
     "#{pluralize(thing.demos.count, 'demo')}, #{total_time(thing)}"
   end
 
-  def tagged_demos(demos)
-    Tag.where(demo: demos).distinct.includes(:sub_category).where(
-      'sub_categories.style & ? > 0', SubCategory.Show).references(:sub_category).count(:demo_id)
-  end
-
   def last_update
     Demo.reorder(:updated_at).last.updated_at
   end

--- a/app/models/demo.rb
+++ b/app/models/demo.rb
@@ -87,17 +87,17 @@ class Demo < ApplicationRecord
   end
 
   def update_tags
-    self.has_hidden_tag = sub_categories.where('style & ? = 0', SubCategory.Show).exists?
-    self.has_shown_tag = sub_categories.where('style & ? > 0', SubCategory.Show).exists?
+    self.has_hidden_tag = sub_categories.hidden.exists?
+    self.has_shown_tag = sub_categories.shown.exists?
     self.save
   end
 
   def hidden_tags_text
-    cell_names(sub_categories.where('style & ? = 0', SubCategory.Show))
+    cell_names(sub_categories.hidden)
   end
 
   def shown_tags_text
-    cell_names(sub_categories.where('style & ? > 0', SubCategory.Show))
+    cell_names(sub_categories.shown)
   end
 
   def players_text

--- a/app/models/sub_category.rb
+++ b/app/models/sub_category.rb
@@ -2,22 +2,7 @@ class SubCategory < ApplicationRecord
   has_many :tags, dependent: :destroy
   has_many :demos, through: :tags
   validates :name,  presence: true, length: { maximum: 50 }
-  validates :style, presence: true,
-                    numericality: { greater_than_or_equal_to: 0 }
 
-  STYLE_SET = ['show']
-  STYLE_SET.each_with_index do |sty, i|
-    mask = 1 << i
-    define_method("#{sty}?") do
-      style & mask > 0
-    end
-    
-    define_method("#{sty}=") do |on|
-      on ? self.style |= mask : self.style &= ~mask
-    end
-    
-    define_singleton_method("#{sty.capitalize}") do
-      mask
-    end
-  end
+  scope :shown, -> { where(show: true) }
+  scope :hidden, -> { where(show: false) }
 end

--- a/app/services/demo_creation_service.rb
+++ b/app/services/demo_creation_service.rb
@@ -41,7 +41,7 @@ class DemoCreationService
   def sub_categories
     @sub_categories ||= @request_hash[:tags]&.map do |tag|
       SubCategory.find_by(name: tag[:text]) ||
-        SubCategory.create(name: tag[:text], show: tag[:style])
+        SubCategory.create(name: tag[:text], show: tag[:show])
     end
   end
 

--- a/app/views/demos/_tag_field.html.erb
+++ b/app/views/demos/_tag_field.html.erb
@@ -10,7 +10,7 @@
       <%= text_field_tag "tags[]", tag.sub_category.name, class: "form-control" %>
       <div class="pull-right">
         <%= check_box_tag "shows[]", "No", true, class: "no-display" %>
-        <%= check_box_tag "shows[]", "Yes", tag.sub_category.show? %> Show by default
+        <%= check_box_tag "shows[]", "Yes", tag.sub_category.show %> Show by default
       </div>
     <% end %>
   </div>

--- a/db/migrate/20180702182355_add_show_to_sub_categories.rb
+++ b/db/migrate/20180702182355_add_show_to_sub_categories.rb
@@ -1,0 +1,14 @@
+class AddShowToSubCategories < ActiveRecord::Migration[5.0]
+  def up
+    add_column :sub_categories, :show, :boolean, default: true
+
+    SubCategory.all.each do |sc|
+      sc.show = sc.style.positive?
+      sc.save!
+    end
+  end
+
+  def down
+    remove_column :sub_categories, :show, :boolean, default: true
+  end
+end

--- a/db/migrate/20180702184459_remove_style_from_sub_categories.rb
+++ b/db/migrate/20180702184459_remove_style_from_sub_categories.rb
@@ -1,0 +1,5 @@
+class RemoveStyleFromSubCategories < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :sub_categories, :style, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171022094213) do
+ActiveRecord::Schema.define(version: 20180702184459) do
 
   create_table "admins", force: :cascade do |t|
     t.string   "username"
@@ -110,9 +110,9 @@ ActiveRecord::Schema.define(version: 20171022094213) do
 
   create_table "sub_categories", force: :cascade do |t|
     t.string   "name"
-    t.integer  "style",      default: 0
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+    t.boolean  "show",       default: true
   end
 
   create_table "tags", force: :cascade do |t|

--- a/test/integration/api/demos_create_test.rb
+++ b/test/integration/api/demos_create_test.rb
@@ -18,7 +18,7 @@ class DemosCreateTest < ActionDispatch::IntegrationTest
         wad: @wad.username,
         category: 'UV Speed',
         players: [players(:kraflab).name],
-        tags: [{ text: 'Also reality', style: 1 }],
+        tags: [{ text: 'Also reality', show: 1 }],
         file: {
           data: '1234',
           name: 'test_demo.zip'

--- a/test/models/sub_category_test.rb
+++ b/test/models/sub_category_test.rb
@@ -1,38 +1,22 @@
 require 'test_helper'
 
 class SubCategoryTest < ActiveSupport::TestCase
-  
+
   def setup
-    @sub = SubCategory.new(name: "sr40 only", style: 2)
+    @sub = SubCategory.new(name: "sr40 only")
   end
-  
+
   test "should be valid" do
     assert @sub.valid?
   end
-  
+
   test "name must be present" do
     @sub.name = " "
     assert_not @sub.valid?
   end
-  
-  test "style must be present" do
-    @sub.style = nil
-    assert_not @sub.valid?
-  end
-  
+
   test "name should not be too long" do
     @sub.name = "a" * 51
     assert_not @sub.valid?
-  end
-  
-  test "style should be >= 0" do
-    @sub.style = -1
-    assert_not @sub.valid?
-  end
-  
-  test "style change should work" do
-    assert_not @sub.show?
-    @sub.show = true
-    assert @sub.show?
   end
 end

--- a/test/services/demo_creation_service_test.rb
+++ b/test/services/demo_creation_service_test.rb
@@ -15,7 +15,7 @@ describe DemoCreationService do
       wad: wad.username,
       category: 'UV Speed',
       players: demo_players.map(&:name),
-      tags: [{ text: 'Also reality', style: 1 }],
+      tags: [{ text: 'Also reality', show: 1 }],
       file: file,
       file_id: file_id
     }


### PR DESCRIPTION
Clear up metaprogramming in favor of explicit style fields, and add scopes to improve encapsulation.