### PR TITLE
Replace tag callbacks

### DIFF
--- a/app/domains/domain/demo/create_tags.rb
+++ b/app/domains/domain/demo/create_tags.rb
@@ -1,0 +1,23 @@
+module Domain
+  module Demo
+    module CreateTags
+      extend self
+
+      def call(demo:, sub_categories:)
+        sub_categories.each do |sc|
+          ::Tag.create!(demo: demo, sub_category: sc)
+        end
+        update_tag_fields(demo)
+      end
+
+      private
+
+      def update_tag_fields(demo)
+        demo.update!(
+          has_hidden_tag: demo.sub_categories.hidden.exists?,
+          has_shown_tag: demo.sub_categories.shown.exists?
+        )
+      end
+    end
+  end
+end

--- a/app/models/demo.rb
+++ b/app/models/demo.rb
@@ -86,12 +86,6 @@ class Demo < ApplicationRecord
     tas != 0 ? (tas > 0 ? "T#{tas}" : 'T') : ''
   end
 
-  def update_tags
-    self.has_hidden_tag = sub_categories.hidden.exists?
-    self.has_shown_tag = sub_categories.shown.exists?
-    self.save
-  end
-
   def hidden_tags_text
     cell_names(sub_categories.hidden)
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -3,17 +3,4 @@ class Tag < ApplicationRecord
   belongs_to :demo, touch: true
   validates :sub_category, presence: true
   validates :demo,         presence: true
-  after_save :update_players, :update_demos
-
-  private
-
-    # if a tag is added to a demo, the player needs to be touched
-    def update_players
-      demo.players.each { |i| i.touch }
-    end
-
-    # reset demo tag flags
-    def update_demos
-      demo.update_tags
-    end
 end

--- a/app/services/demo_creation_service.rb
+++ b/app/services/demo_creation_service.rb
@@ -8,13 +8,20 @@ class DemoCreationService
   end
 
   def create!
-    new_demo.tap { |demo| demo.save! }
+    Demo.transaction do
+      demo.save!
+      Domain::Demo::CreateTags.call(
+        demo: demo, sub_categories: sub_categories
+      )
+    end
+
+    demo
   end
 
   private
 
-  def new_demo
-    Demo.new(demo_attributes)
+  def demo
+    @demo ||= Demo.new(demo_attributes)
   end
 
   def demo_attributes
@@ -23,8 +30,7 @@ class DemoCreationService
 
   def associations
     {
-      wad: wad, demo_file: demo_file, players: players,
-      sub_categories: sub_categories, category: category
+      wad: wad, demo_file: demo_file, players: players, category: category
     }.reject { |k, v| v.nil? }
   end
 

--- a/test/domains/domain/demo/create_tags_test.rb
+++ b/test/domains/domain/demo/create_tags_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+describe Domain::Demo::CreateTags do
+  let(:params) {
+    {
+      demo: demo,
+      sub_categories: [sub_category]
+    }
+  }
+  let(:demo) { demos(:bt01speed) }
+  let(:sub_category) { sub_categories(:reality) }
+  let(:create_tags) { Domain::Demo::CreateTags.call(params) }
+
+  it 'creates a tag' do
+    Tag.expects(:create!).with(demo: demo, sub_category: sub_category)
+    create_tags
+  end
+
+  it 'updates demo tag fields' do
+    create_tags
+    demo.has_shown_tag.must_equal true
+    demo.has_hidden_tag.must_equal false
+  end
+end

--- a/test/fixtures/sub_categories.yml
+++ b/test/fixtures/sub_categories.yml
@@ -1,0 +1,3 @@
+reality:
+  show: true
+  name: Also reality


### PR DESCRIPTION
Remove callbacks from the tag model, as well as some cursory logic in the demo model, in favor of a tag creation object in the demo domain. This also inevitably reduces the number of transactions in the case of bulk tagging.