### PR TITLE
Cleanup player stats

### DIFF
--- a/app/domains/domain/player/stats.rb
+++ b/app/domains/domain/player/stats.rb
@@ -12,7 +12,7 @@ module Domain
           total_demo_time: total_demo_time(player),
           average_demo_count: average_demo_count(player),
           most_recorded_wad: most_recorded_wad(player),
-          most_recorded_category: most_recorded_category(player)
+          most_recorded_category: most_recorded_category(player),
           tas_count: tas_count(player),
           wad_count: wad_count(player),
           demo_count: demo_count(player)
@@ -29,7 +29,7 @@ module Domain
         ::Demo.tics_to_string(player.demos.sum(:tics) / player.demos.count)
       end
 
-      def total_demo_time
+      def total_demo_time(player)
         ::Demo.tics_to_string(player.demos.sum(:tics))
       end
 

--- a/app/domains/domain/player/stats.rb
+++ b/app/domains/domain/player/stats.rb
@@ -1,0 +1,64 @@
+# This file is certainly violating domain boundaries
+# It is a temporary step on the path to encapsulation
+module Domain
+  module Player
+    module Stats
+      extend self
+
+      def call(player)
+        OpenStruct.new(
+          longest_demo_time: longest_demo_time(player),
+          average_demo_time: average_demo_time(player),
+          total_demo_time: total_demo_time(player),
+          average_demo_count: average_demo_count(player),
+          most_recorded_wad: most_recorded_wad(player),
+          most_recorded_category: most_recorded_category(player)
+          tas_count: tas_count(player),
+          wad_count: wad_count(player),
+          demo_count: demo_count(player)
+        )
+      end
+
+      private
+
+      def longest_demo_time(player)
+        ::Demo.tics_to_string(player.demos.maximum(:tics))
+      end
+
+      def average_demo_time(player)
+        ::Demo.tics_to_string(player.demos.sum(:tics) / player.demos.count)
+      end
+
+      def total_demo_time
+        ::Demo.tics_to_string(player.demos.sum(:tics))
+      end
+
+      def average_demo_count(player)
+        wad_counts = player.demos.group(:wad_id).count
+        wad_counts.values.inject(0) { |sum, k| sum + k } / wad_counts.size
+      end
+
+      def most_recorded_wad(player)
+        wad_counts = player.demos.group(:wad_id).count
+        ::Wad.find(wad_counts.max_by { |k, v| v }[0]).name
+      end
+
+      def most_recorded_category(player)
+        category_counts = player.demos.group(:category_id).count
+        ::Category.find(category_counts.max_by { |k, v| v }[0]).name
+      end
+
+      def tas_count(player)
+        player.demos.tas.count
+      end
+
+      def wad_count(player)
+        player.demos.select(:wad_id).distinct.count
+      end
+
+      def demo_count(player)
+        player.demos.count
+      end
+    end
+  end
+end

--- a/app/helpers/players_helper.rb
+++ b/app/helpers/players_helper.rb
@@ -58,31 +58,18 @@ module PlayersHelper
   end
 
   def player_stats(player, hash = {})
-    hash[:longest_demo] = Demo.tics_to_string(player.demos.maximum(:tics))
-    hash[:total_time], hash[:average_time] = time_stats(player, false)
-    hash[:demo_count] ||= player.demos.count
-    hash[:wad_count] ||= player_wad_count(player)
-
-    # group wads by number of demos by this player, get average / max
-    wad_counts = DemoPlayer.where(player: player).includes(:demo).group('demos.wad_id').references(:demo).count
-    top_wad = Wad.find(wad_counts.max_by { |k, v| v }[0])
-    hash[:average_demo_count] = wad_counts.keys.inject { |sum, k| sum + k } / wad_counts.size
-    hash[:top_wad] = top_wad.name
-
-    # group demos by category
-    category_counts = DemoPlayer.where(player: player).includes(:demo).group('demos.category_id').references(:demo).count
-    top_category = Category.find(category_counts.max_by { |k, v| v }[0])
-    hash[:top_category] = top_category.name
-
-    hash[:tas_count] ||= DemoPlayer.where(player: player).includes(:demo).where('demos.tas > 0').references(:demo).count
+    hash[:longest_demo] = player.longest_demo_time
+    hash[:total_time] = player.total_demo_time
+    hash[:average_time] = player.average_demo_time
+    hash[:demo_count] ||= player.demo_count
+    hash[:wad_count] ||= player.wad_count
+    hash[:average_demo_count] = player.average_demo_count
+    hash[:top_wad] = player.most_recorded_wad
+    hash[:top_category] = player.most_recorded_category
+    hash[:tas_count] ||= player.tas_count
     hash
   end
 
   def edit_player_link(player)
-  end
-
-  def player_wad_count(player)
-    DemoPlayer.where(player: player).includes(:demo).select('demos.wad_id').
-      references(:demo).distinct.count
   end
 end

--- a/app/models/demo.rb
+++ b/app/models/demo.rb
@@ -18,6 +18,7 @@ class Demo < ApplicationRecord
   }
   scope :recent, -> (n) { reorder(recorded_at: :desc).limit(n) }
   scope :within, -> (n) { reorder(recorded_at: :desc).where('recorded_at >= ?', n.days.ago)}
+  scope :tas, -> { where('tas > 0') }
 
   validates :wad,       presence: true
   validates :category,  presence: true

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -15,7 +15,7 @@ class Player < ApplicationRecord
 
  delegate :longest_demo_time, :average_demo_time, :total_demo_time,
           :average_demo_count, :most_recorded_wad, :most_recorded_category,
-          :tas_count, :wad_count, :demo_count
+          :tas_count, :wad_count, :demo_count,
           to: :stats
 
   # Calculate and save the record index for a set of players (all by default)


### PR DESCRIPTION
Pulls out a lot of logic that doesn't belong in the player model. Also wipes out duplicate / different implementation of the same stats from elsewhere in the code.