### PR TITLE
Cleanup model calls

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,11 +11,6 @@ class ApplicationController < ActionController::Base
     @current_admin = AdminAuthenticator.new(request).authenticate!
   end
 
-  # Basic api check for file data
-  def has_file_data?(query)
-    query['file'] and query['file']['data'] and query['file']['name']
-  end
-
   def preprocess_api_request(options)
     @request_hash = ApiRequestParser.new(options.merge(request: request)).parse_json
   end

--- a/app/controllers/demos_controller.rb
+++ b/app/controllers/demos_controller.rb
@@ -8,7 +8,7 @@ class DemosController < ApplicationController
                             else
                               [:order_by_update, :updated_at]
                             end
-    @demos = Domain::Demo.list(page: params[:page] || 1, sort_key => true)
+    @demos = Domain::Demo.list(page: params[:page] || 1, sort_key => :desc)
   end
 
   def api_create

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,7 +5,7 @@ class SessionsController < ApplicationController
 
   def set
     demo_filter = {category: [], tas: false, coop: false, port: []}
-    Category.all.each do |category|
+    Domain::Category.list.each do |category|
       demo_filter[:category].push(category.name) if params["cat:#{category.name}"] == '0'
     end
     demo_filter[:tas] = params['tas'] == '0'

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -15,7 +15,7 @@ class StaticPagesController < ApplicationController
   def search
     @search = params[:search]
     @players = Domain::Player.search(term: @search)
-    @wads = Wad.where('username LIKE ?', "%#{@search}%")
+    @wads = Domain::Wad.search(term: @search)
   end
 
   def no_file

--- a/app/controllers/wads_controller.rb
+++ b/app/controllers/wads_controller.rb
@@ -40,12 +40,12 @@ class WadsController < ApplicationController
   def record_timeline_json
     @wad = Domain::Wad.single(short_name: params[:id], assert: true)
     level = params[:level]
-    category = Domain::Category.single(name: params[:category])
+    category = params[:category]
     demos = Domain::Demo.list(
       wad_id: @wad.id, level: level, category: category, guys: 1, tas: 0,
       order_by_record_date: :asc
     )
-    data_full = demos.all.map { |i| [i.players.first.username, i.tics, i.time, i.recorded_at] }
+    data_full = demos.map { |i| [i.players.first.username, i.tics, i.time, i.recorded_at] }
     if data_full.empty?
       render json: {data: [], players: [], error: true}
     else

--- a/app/controllers/wads_controller.rb
+++ b/app/controllers/wads_controller.rb
@@ -40,7 +40,7 @@ class WadsController < ApplicationController
   def record_timeline_json
     @wad = Domain::Wad.single(short_name: params[:id], assert: true)
     level = params[:level]
-    category = Category.find_by(name: params[:category])
+    category = Domain::Category.single(name: params[:category])
     demos = Domain::Demo.list(
       wad_id: @wad.id, level: level, category: category, guys: 1, tas: 0,
       order_by_record_date: :asc

--- a/app/controllers/wads_controller.rb
+++ b/app/controllers/wads_controller.rb
@@ -77,7 +77,7 @@ class WadsController < ApplicationController
     index_0 = params[:index_0].to_i
     index_1 = params[:index_1].to_i
     demos = Domain::Demo.list(
-      level: level, category: category, wad: wad.id, guys: 1, tas: 0
+      level: level, category: category, wad_id: wad.id, guys: 1, tas: 0
     )
     demo_0 = demos[index_0]
     demo_1 = demos[index_1]
@@ -93,7 +93,7 @@ class WadsController < ApplicationController
     @level = params[:level]
     @category = params[:category]
     @demos = Domain::Demo.list(
-      level: @level, category: @category, wad: @wad.id, guys: 1, tas: 0
+      level: @level, category: @category, wad_id: @wad.id, guys: 1, tas: 0
     )
     if @level.nil? or !@level.include?('Ep') or @demos.count < 2
       if @wad.nil?

--- a/app/controllers/wads_controller.rb
+++ b/app/controllers/wads_controller.rb
@@ -41,7 +41,10 @@ class WadsController < ApplicationController
     @wad = Domain::Wad.single(short_name: params[:id], assert: true)
     level = params[:level]
     category = Category.find_by(name: params[:category])
-    demos = Demo.where(level: level, category: category, wad: @wad, guys: 1, tas: 0).reorder(:recorded_at)
+    demos = Domain::Demo.list(
+      wad_id: @wad.id, level: level, category: category, guys: 1, tas: 0,
+      order_by_record_date: :asc
+    )
     data_full = demos.all.map { |i| [i.players.first.username, i.tics, i.time, i.recorded_at] }
     if data_full.empty?
       render json: {data: [], players: [], error: true}
@@ -73,7 +76,9 @@ class WadsController < ApplicationController
     category = params[:category]
     index_0 = params[:index_0].to_i
     index_1 = params[:index_1].to_i
-    demos = Demo.where(level: level, category: Category.find_by(name: category), wad: wad, guys: 1, tas: 0)
+    demos = Domain::Demo.list(
+      level: level, category: category, wad: wad.id, guys: 1, tas: 0
+    )
     demo_0 = demos[index_0]
     demo_1 = demos[index_1]
     if level.nil? or !level.include?('Ep') or demo_0.nil? or demo_1.nil?
@@ -87,7 +92,9 @@ class WadsController < ApplicationController
     @wad = Domain::Wad.single(short_name: params[:id], assert: true)
     @level = params[:level]
     @category = params[:category]
-    @demos = Demo.where(level: @level, category: Category.find_by(name: @category), wad: @wad, guys: 1, tas: 0)
+    @demos = Domain::Demo.list(
+      level: @level, category: @category, wad: @wad.id, guys: 1, tas: 0
+    )
     if @level.nil? or !@level.include?('Ep') or @demos.count < 2
       if @wad.nil?
         flash[:info] = 'Wad not found'

--- a/app/domains/domain/category.rb
+++ b/app/domains/domain/category.rb
@@ -1,0 +1,41 @@
+module Domain
+  module Player
+    extend self
+
+    SKILL_4_SPEED = ['UV Speed', 'SM Speed'].freeze
+
+    def list(soft_category: nil, only: nil)
+      return categories_for(soft_category) if soft_category
+      return skill_4_speed if only == :skill_4_speed
+      ::Category.all
+    end
+
+    def single(name: nil, id: nil, assert: false)
+      category = nil
+      category = ::Category.find_by(name: name) if name
+      category = ::Category.find_by(id: id) if id
+      return category if category.present?
+      raise ActiveRecord::RecordNotFound if assert
+    end
+
+    private
+
+    def categories_for(name)
+      categories = [::Category.find_by(name: name)]
+      categories << pacifist if skill_4_speed?(name)
+      categories
+    end
+
+    def skill_4_speed?(name)
+      SKILL_4_SPEED.include?(name)
+    end
+
+    def skill_4_speed
+      SKILL_4_SPEED.map { |name| ::Category.find_by(name: name) }
+    end
+
+    def pacifist
+      ::Category.find_by(name: 'Pacifist')
+    end
+  end
+end

--- a/app/domains/domain/category.rb
+++ b/app/domains/domain/category.rb
@@ -1,5 +1,5 @@
 module Domain
-  module Player
+  module Category
     extend self
 
     SKILL_4_SPEED = ['UV Speed', 'SM Speed'].freeze

--- a/app/domains/domain/demo.rb
+++ b/app/domains/domain/demo.rb
@@ -36,7 +36,7 @@ module Domain
       recorded_at: nil, engine: 'Unknown', file: nil, file_id: nil
     )
       wad = Domain::Wad.single(either_name: wad)
-      category = ::Category.find_by(name: category)
+      category = Domain::Category.single(name: category)
       players = players_from_names(players)
       Domain::Demo::Create.call(
         wad: wad,
@@ -65,8 +65,8 @@ module Domain
     end
 
     def resolve_categories(category, soft_category)
-      return ::Category.find_by(name: category) if category
-      return ::Category.categories_for(soft_category) if soft_category
+      return Domain::Category.single(name: category) if category
+      return Domain::Category.list(soft_category: soft_category) if soft_category
     end
   end
 end

--- a/app/domains/domain/demo.rb
+++ b/app/domains/domain/demo.rb
@@ -24,8 +24,8 @@ module Domain
       query = query.where(tas: tas) if tas
       query = query.where(guys: guys) if guys
       query = query.reorder(:tics) if order_by_tics
-      query = query.reorder(recorded_at: :desc) if order_by_record_date
-      query = query.reorder(updated_at: :desc) if order_by_update
+      query = query.reorder(recorded_at: order_by_record_date) if order_by_record_date
+      query = query.reorder(updated_at: order_by_update) if order_by_update
       query = query.page(page) if page
       query
     end

--- a/app/domains/domain/demo/compute_record_index.rb
+++ b/app/domains/domain/demo/compute_record_index.rb
@@ -4,7 +4,7 @@ module Domain
       extend self
 
       def call(demo)
-        categories = ::Category.categories_for(demo.category.name)
+        categories = Domain::Category.list(soft_category: demo.category.name)
         return unless best?(demo, categories)
         record_index(demo, categories)
       end
@@ -31,7 +31,7 @@ module Domain
       def index_categories(demo, categories)
         categories.pop(categories.size - 1) if categories.size > 1
         if demo.category.name == 'Pacifist'
-          categories.push(*::Category.skill_4_speed)
+          categories.push(*Domain::Category.list(only: :skill_4_speed))
           # Only add speed category if pacifist is also the speed record
           categories.pop(categories.size - 1) unless best?(demo, categories)
         end

--- a/app/domains/domain/player/stats.rb
+++ b/app/domains/domain/player/stats.rb
@@ -45,7 +45,9 @@ module Domain
 
       def most_recorded_category(player)
         category_counts = player.demos.group(:category_id).count
-        ::Category.find(category_counts.max_by { |k, v| v }[0]).name
+        Domain::Category.single(
+          id: category_counts.max_by { |k, v| v }[0]
+        )&.name
       end
 
       def tas_count(player)

--- a/app/domains/domain/player/stats.rb
+++ b/app/domains/domain/player/stats.rb
@@ -40,7 +40,7 @@ module Domain
 
       def most_recorded_wad(player)
         wad_counts = player.demos.group(:wad_id).count
-        Domain::Wad.single(wad_counts.max_by { |k, v| v }[0])&.name
+        Domain::Wad.single(id: wad_counts.max_by { |k, v| v }[0])&.name
       end
 
       def most_recorded_category(player)

--- a/app/domains/domain/player/stats.rb
+++ b/app/domains/domain/player/stats.rb
@@ -40,7 +40,7 @@ module Domain
 
       def most_recorded_wad(player)
         wad_counts = player.demos.group(:wad_id).count
-        ::Wad.find(wad_counts.max_by { |k, v| v }[0]).name
+        Domain::Wad.single(wad_counts.max_by { |k, v| v }[0])&.name
       end
 
       def most_recorded_category(player)

--- a/app/domains/domain/wad.rb
+++ b/app/domains/domain/wad.rb
@@ -14,10 +14,11 @@ module Domain
       ::Wad.where('username LIKE ? OR name LIKE ?', "%#{term}%", "%#{term}%")
     end
 
-    def single(short_name: nil, either_name: nil, assert: false)
+    def single(short_name: nil, either_name: nil, id: nil, assert: false)
       wad = nil
       wad = ::Wad.find_by(username: short_name) if short_name
       wad = find_by_either_name(either_name) if either_name
+      wad = ::Wad.find_by(id: id) if id
       return wad if wad.present?
       raise ActiveRecord::RecordNotFound if assert
     end

--- a/app/domains/domain/wad.rb
+++ b/app/domains/domain/wad.rb
@@ -10,6 +10,10 @@ module Domain
       query
     end
 
+    def search(term:)
+      ::Wad.where('username LIKE ? OR name LIKE ?', "%#{term}%", "%#{term}%")
+    end
+
     def single(short_name: nil, either_name: nil, assert: false)
       wad = nil
       wad = ::Wad.find_by(username: short_name) if short_name

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -4,26 +4,4 @@ class Category < ApplicationRecord
                           uniqueness: true
   validates :description, presence: true, length: { maximum: 200 }
   validates :game,        presence: true, length: { maximum: 50 }
-
-  SKILL_4_SPEED = ['UV Speed', 'SM Speed'].freeze
-
-  class << self
-    def categories_for(name)
-      categories = [Category.find_by(name: name)]
-      categories << pacifist if skill_4_speed?(name)
-      categories
-    end
-
-    def skill_4_speed?(name)
-      SKILL_4_SPEED.include?(name)
-    end
-
-    def skill_4_speed
-      SKILL_4_SPEED.map { |name| Category.find_by(name: name) }
-    end
-
-    def pacifist
-      Category.find_by(name: 'Pacifist')
-    end
-  end
 end

--- a/test/domains/domain/category_test.rb
+++ b/test/domains/domain/category_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+describe Domain::Category do
+  describe '.list' do
+    it 'returns a list of categories' do
+      Domain::Category.list.first.must_be_instance_of Category
+    end
+
+    describe 'when using a soft category' do
+      it 'returns related categories' do
+        Domain::Category.list(soft_category: 'UV Speed')
+          .map(&:name).must_equal ['UV Speed', 'Pacifist']
+      end
+    end
+
+    describe 'when asking for only skill 4 speed categories' do
+      it 'returns them' do
+        Domain::Category.list(only: :skill_4_speed)
+          .map(&:name).must_equal ['UV Speed', 'SM Speed']
+      end
+    end
+  end
+
+  describe '.single' do
+    let(:category) { categories(:uvspeed) }
+
+    it 'returns a category' do
+      Domain::Category.single(name: category.name).must_equal category
+    end
+
+    describe 'when using id' do
+      it 'returns a category' do
+        Domain::Category.single(id: category.id).must_equal category
+      end
+    end
+
+    describe 'when the category does not exist' do
+      let(:single) {
+        Domain::Category.single(name: 'not found', assert: assert_presence)
+      }
+
+      describe 'when asserting presence' do
+        let(:assert_presence) { true }
+
+        it 'raises error' do
+          proc { single }.must_raise ActiveRecord::RecordNotFound
+        end
+      end
+
+      describe 'when not asserting presence' do
+        let(:assert_presence) { false }
+
+        it 'returns nil' do
+          single.must_be_nil
+        end
+      end
+    end
+  end
+end

--- a/test/domains/domain/wad_test.rb
+++ b/test/domains/domain/wad_test.rb
@@ -30,6 +30,14 @@ describe Domain::Wad do
     end
   end
 
+  describe '.search' do
+    let(:wad) { wads(:btsx) }
+
+    it 'returns wads matching a search term' do
+      Domain::Wad.search(term: wad.username).first.must_equal wad
+    end
+  end
+
   describe '.single' do
     let(:wad) { wads(:btsx) }
 


### PR DESCRIPTION
With the main domains laid out, we can do a second pass over the controllers and domains to remove extraneous model calls. This adds a category domain, which simplifies the category model and improves agnosticism elsewhere in the code.

There are still direct model calls inside of domains that are questionable (e.g., with handling join tables). Additionally, there are plenty of calls that still know too much (either via association chaining, or attaching active record queries onto results) that should be replaced in the future.

This PR removes the easy / main offenders though.