### PR TITLE
Add allowed ports table

### DIFF
--- a/app/helpers/ports_helper.rb
+++ b/app/helpers/ports_helper.rb
@@ -1,6 +1,16 @@
 module PortsHelper
 
-  def ports_header(ports)
-    content_tag(:h1, 'Port List')
+  def ports_table(ports, allowed)
+    ports.group_by(&:family).map do |family, ports|
+      content_tag(:tr) do
+        content_tag(:td, family) +
+        content_tag(:td) do
+          ports.each_with_index.map do |port, index|
+            link = link_to(port.version, port.file_path)
+            index == ports.size - 1 ? link : (link + ', ')
+          end.join.html_safe
+        end
+      end
+    end.join.html_safe
   end
 end

--- a/app/views/ports/index.html.erb
+++ b/app/views/ports/index.html.erb
@@ -3,31 +3,53 @@
 
 <div class="center-text">
   <h4>
-    This is the list of ports needed
-    to play back the demos you find on the archive.
+    This is the list of ports allowed
+    for recording most demos.
+    <br>
+    <a href="https://www.doomworld.com/forum/topic/149931-source-port-enforcement-announcement-for-dsda-submissions/">Source port enforcement thread</a>
   </h4>
   <h4>
     What port you should use to <i>record</i> demos
-    depends on the intended environment for each wad.
+    depends on the intended environment for each WAD.
+    <br>
+    Some WADS may require a port from the Archived list
   </h4>
-  <%= ports_header(@ports) %>
 
-  <div class="panel panel-default panel-modest left-text">
-    <table class="table table-striped">
-      <tbody>
-        <% @ports.chunk { |i| i.family }.each do |chunk| %>
-          <tr>
-            <td><%= chunk[0] %></td>
-            <td>
-              <% last = chunk[1].pop %>
-              <% chunk[1].each do |port| %>
-                <%= link_to port.version, port.file_path %>,
-              <% end %>
-              <%= link_to last.version, last.file_path %>
-            </td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
+    <div class="hidden-overflow">
+      <div class="center-text">
+        <div class="panel panel-default panel-modest">
+          <div class="panel-heading">
+            <h3 class="panel-title">Allowed</h3>
+          </div>
+          <table class="table table-striped left-text">
+            <tr>
+              <td>DSDA-Doom</td>
+              <td><a href="https://github.com/kraflab/dsda-doom/releases">v0.28.2 or newer</a></td>
+            </tr>
+            <tr>
+              <td>Woof</td>
+              <td><a href="https://github.com/fabiangreffrath/woof/releases">v14.5.0 or newer</a></td>
+            </tr>
+            <tr>
+              <td>Crispy-Doom</td>
+              <td><a href="https://github.com/fabiangreffrath/crispy-doom/releases">v7.0.0 or newer</a></td>
+            </tr>
+            <tr>
+              <td>Vanilla EXEs</td>
+              <td>Doom, Doom 2, Final Doom</td>
+            </tr>
+          </table>
+        </div>
+      </div>
+      <div class="center-text">
+        <div class="panel panel-default panel-modest">
+          <div class="panel-heading">
+            <h3 class="panel-title">Archived</h3>
+          </div>
+          <table class="table table-striped left-text">
+            <%= ports_table(@ports, false) %>
+          </table>
+        </div>
+      </div>
+    </div>
 </div>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -7,7 +7,7 @@
     <p>
       The home of classic Doom speedrunning.
       This site archives demos created for Doom and related games
-      (Heretic, Hexen, etc).  Demos may be recorded using any source port,
+      (Heretic, Hexen, etc).  <%= link_to('Ports', ports_path) %> has a list of allowed ports,
       although care should be taken to use the intended environment for each
       WAD.  Post your demos to the
       <a href="https://www.doomworld.com/forum/37-doom-speed-demos/">Speed Demo Forum</a>


### PR DESCRIPTION
Would be better if the allowed ports were managed in the database and were exposed by the api, but this is good enough for now. I dont expect them to change much.

The links go to the github releases of each port.

![Screenshot 2025-05-29 at 13 53 44](https://github.com/user-attachments/assets/c945fac5-96f7-4c26-85c8-5ecd48e33b42)
